### PR TITLE
Harden Ghostfolio API provider payload and numeric validation

### DIFF
--- a/app/data_sources/ghostfolio_api_provider.py
+++ b/app/data_sources/ghostfolio_api_provider.py
@@ -7,22 +7,50 @@ class GhostfolioAPIDataProvider:
     def __init__(self, client: GhostfolioClient) -> None:
         self.client = client
 
+    @staticmethod
+    def _parse_required_float(value: Any, field_name: str, context: str) -> float:
+        try:
+            if value is None:
+                raise ValueError
+            return float(value)
+        except (TypeError, ValueError):
+            raise ValueError(f"{context} has invalid required numeric field '{field_name}'")
+
+    @staticmethod
+    def _parse_optional_float(value: Any) -> float | None:
+        try:
+            if value is None:
+                return None
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
     async def get_portfolio_summary(self, account_id: str | None = None) -> dict[str, Any]:
         response = await self.client.get_portfolio_holdings(account_id=account_id)
         if not isinstance(response, list):
             raise ValueError("Expected holdings list from Ghostfolio API")
 
-        total_value = float(sum(item.get("marketValue", 0.0) for item in response))
-        holdings = [
-            {
-                "symbol": item.get("symbol"),
-                "name": item.get("name"),
-                "allocation_pct": item.get("allocationInPercentage"),
-                "value": item.get("marketValue"),
-                "performance_pct": item.get("performanceInPercentage"),
-            }
-            for item in response
-        ]
+        holdings: list[dict[str, Any]] = []
+        for index, item in enumerate(response):
+            if not isinstance(item, dict):
+                raise ValueError(f"Holding at index {index} must be an object")
+            symbol = item.get("symbol")
+            name = item.get("name")
+            if not symbol or not name:
+                raise ValueError(f"Holding at index {index} is missing required symbol or name")
+            holdings.append(
+                {
+                    "symbol": symbol,
+                    "name": name,
+                    "allocation_pct": self._parse_optional_float(item.get("allocationInPercentage")),
+                    "value": self._parse_required_float(
+                        item.get("marketValue"), "marketValue", f"Holding at index {index}"
+                    ),
+                    "performance_pct": self._parse_optional_float(item.get("performanceInPercentage")),
+                }
+            )
+
+        total_value = sum(item["value"] for item in holdings)
         return {
             "total_value": total_value,
             "currency": "USD",
@@ -32,10 +60,12 @@ class GhostfolioAPIDataProvider:
 
     async def get_performance(self, query_range: str) -> dict[str, Any]:
         response = await self.client.get_portfolio_performance(query_range=query_range)
+        if not isinstance(response, dict):
+            raise ValueError("Expected performance object from Ghostfolio API")
         return {
             "range": query_range,
-            "return_pct": float(response.get("performance", 0.0)),
-            "absolute_gain": float(response.get("value", 0.0)),
+            "return_pct": self._parse_required_float(response.get("performance"), "performance", "Performance payload"),
+            "absolute_gain": self._parse_required_float(response.get("value"), "value", "Performance payload"),
             "currency": "USD",
         }
 
@@ -43,15 +73,20 @@ class GhostfolioAPIDataProvider:
         response = await self.client.get_orders()
         if not isinstance(response, list):
             raise ValueError("Expected transaction list from Ghostfolio API")
-        return [
-            {
-                "date": item.get("date"),
-                "type": item.get("type"),
-                "symbol": item.get("symbol"),
-                "quantity": item.get("quantity"),
-                "unit_price": item.get("unitPrice"),
-                "fee": item.get("fee"),
-                "currency": item.get("currency", "USD"),
-            }
-            for item in response
-        ]
+
+        transactions: list[dict[str, Any]] = []
+        for index, item in enumerate(response):
+            if not isinstance(item, dict):
+                raise ValueError(f"Transaction at index {index} must be an object")
+            transactions.append(
+                {
+                    "date": item.get("date"),
+                    "type": item.get("type"),
+                    "symbol": item.get("symbol"),
+                    "quantity": self._parse_optional_float(item.get("quantity")),
+                    "unit_price": self._parse_optional_float(item.get("unitPrice")),
+                    "fee": self._parse_optional_float(item.get("fee")),
+                    "currency": item.get("currency", "USD"),
+                }
+            )
+        return transactions

--- a/tests/test_ghostfolio_api_provider.py
+++ b/tests/test_ghostfolio_api_provider.py
@@ -1,0 +1,144 @@
+import pytest
+
+from app.data_sources.ghostfolio_api_provider import GhostfolioAPIDataProvider
+
+
+class FakeClient:
+    def __init__(self, holdings, performance, orders):
+        self._holdings = holdings
+        self._performance = performance
+        self._orders = orders
+
+    async def get_portfolio_holdings(self, account_id: str | None = None):
+        _ = account_id
+        return self._holdings
+
+    async def get_portfolio_performance(self, query_range: str):
+        _ = query_range
+        return self._performance
+
+    async def get_orders(self):
+        return self._orders
+
+
+@pytest.mark.asyncio
+async def test_portfolio_summary_raises_for_non_list_holdings():
+    provider = GhostfolioAPIDataProvider(FakeClient(holdings={"bad": "shape"}, performance={}, orders=[]))
+    with pytest.raises(ValueError, match="Expected holdings list"):
+        await provider.get_portfolio_summary()
+
+
+@pytest.mark.asyncio
+async def test_portfolio_summary_raises_for_missing_required_fields():
+    provider = GhostfolioAPIDataProvider(
+        FakeClient(
+            holdings=[{"name": "Apple Inc.", "marketValue": 1000}],
+            performance={},
+            orders=[],
+        )
+    )
+    with pytest.raises(ValueError, match="missing required symbol or name"):
+        await provider.get_portfolio_summary()
+
+
+@pytest.mark.asyncio
+async def test_portfolio_summary_raises_for_invalid_required_market_value():
+    provider = GhostfolioAPIDataProvider(
+        FakeClient(
+            holdings=[
+                {
+                    "symbol": "AAPL",
+                    "name": "Apple Inc.",
+                    "marketValue": "not-a-number",
+                    "allocationInPercentage": None,
+                    "performanceInPercentage": "bad",
+                }
+            ],
+            performance={},
+            orders=[],
+        )
+    )
+    with pytest.raises(ValueError, match="invalid required numeric field 'marketValue'"):
+        await provider.get_portfolio_summary()
+
+
+@pytest.mark.asyncio
+async def test_portfolio_summary_sets_invalid_optional_numeric_fields_to_none():
+    provider = GhostfolioAPIDataProvider(
+        FakeClient(
+            holdings=[
+                {
+                    "symbol": "AAPL",
+                    "name": "Apple Inc.",
+                    "marketValue": 1000,
+                    "allocationInPercentage": "bad",
+                    "performanceInPercentage": None,
+                }
+            ],
+            performance={},
+            orders=[],
+        )
+    )
+    result = await provider.get_portfolio_summary()
+    assert result["total_value"] == 1000.0
+    assert result["holdings"][0]["allocation_pct"] is None
+    assert result["holdings"][0]["performance_pct"] is None
+
+
+@pytest.mark.asyncio
+async def test_performance_raises_for_non_object_payload():
+    provider = GhostfolioAPIDataProvider(FakeClient(holdings=[], performance=["bad"], orders=[]))
+    with pytest.raises(ValueError, match="Expected performance object"):
+        await provider.get_performance("ytd")
+
+
+@pytest.mark.asyncio
+async def test_performance_raises_for_invalid_required_numeric_fields():
+    provider = GhostfolioAPIDataProvider(
+        FakeClient(
+            holdings=[],
+            performance={"performance": "bad", "value": 100},
+            orders=[],
+        )
+    )
+    with pytest.raises(ValueError, match="invalid required numeric field 'performance'"):
+        await provider.get_performance("ytd")
+
+
+@pytest.mark.asyncio
+async def test_transactions_raises_for_non_list_payload():
+    provider = GhostfolioAPIDataProvider(FakeClient(holdings=[], performance={}, orders={"bad": "shape"}))
+    with pytest.raises(ValueError, match="Expected transaction list"):
+        await provider.get_transactions()
+
+
+@pytest.mark.asyncio
+async def test_transactions_raises_for_non_object_entry():
+    provider = GhostfolioAPIDataProvider(FakeClient(holdings=[], performance={}, orders=["bad"]))
+    with pytest.raises(ValueError, match="Transaction at index 0 must be an object"):
+        await provider.get_transactions()
+
+
+@pytest.mark.asyncio
+async def test_transactions_set_invalid_optional_numeric_fields_to_none():
+    provider = GhostfolioAPIDataProvider(
+        FakeClient(
+            holdings=[],
+            performance={},
+            orders=[
+                {
+                    "date": "2026-02-20",
+                    "type": "BUY",
+                    "symbol": "AAPL",
+                    "quantity": "bad",
+                    "unitPrice": None,
+                    "fee": "bad",
+                    "currency": "USD",
+                }
+            ],
+        )
+    )
+    transactions = await provider.get_transactions()
+    assert transactions[0]["quantity"] is None
+    assert transactions[0]["unit_price"] is None
+    assert transactions[0]["fee"] is None


### PR DESCRIPTION
## Summary
- add strict payload-shape checks for holdings, performance, and transactions responses
- enforce required numeric fields as validation errors (instead of silent coercion)
- treat optional numeric fields as nullable (`None`) instead of defaulting to `0.0`
- add malformed payload tests for provider behavior across bad shapes/types

## Test plan
- [x] `python -m pytest -q`
- [x] verify provider malformed-payload tests pass

Made with [Cursor](https://cursor.com)