### PR TITLE
Fix: wire Langfuse observability into agent

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -105,6 +105,7 @@ async def chat(request: ChatRequest) -> ChatResponse:
         query=request.message,
         session_history=session_history,
         tool_context=tool_context,
+        session_id=request.session_id,
     )
     logger.info(
         "chat_completed",


### PR DESCRIPTION
## Summary
- Langfuse tracing functions (`create_trace`, `log_tool_call`, `log_llm_call`, `log_verification`, `flush`) were defined in `app/observability.py` but never imported or called — all traces were silently no-ops
- Wired tracing into `run_agent()` so every request creates a Langfuse trace with tool calls, LLM generations, verification results, and timing
- Passed `session_id` from the `/chat` endpoint through to `run_agent()` for session-grouped traces

## Test plan
- [x] All 57 tests pass
- [x] Ruff lint clean
- [ ] Deploy and verify traces appear in Langfuse dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)