### PR TITLE
Update observability to Langfuse v3 SDK API

### DIFF
--- a/app/agent.py
+++ b/app/agent.py
@@ -871,6 +871,7 @@ async def run_agent(
         output=output.get("response", ""),
         metadata={"mode": mode, "tool_calls": output.get("tool_calls", []), "duration_ms": timing["elapsed_ms"]},
     )
+    trace.end()
     flush()
 
     return output


### PR DESCRIPTION
- Replace removed `client.trace()` with `client.start_span()` for root
- Replace deprecated `start_generation()` with `start_observation(as_type="generation")`
- Use `update_current_trace()` to attach session_id and metadata
- Call `trace.end()` to close the root span before flushing