### PR TITLE
Fix transactions showing oldest instead of newest

### DIFF
--- a/app/agent.py
+++ b/app/agent.py
@@ -351,13 +351,15 @@ def _synthesize_response(state: AgentState) -> tuple[str, bool]:
             response = f"I did not find matching recent transactions.\n\n{DISCLAIMER}"
             return response, True
 
-        first = txs[0]
-        snippet = (
-            f"Most recent transaction: {first.get('type')} {first.get('quantity')} "
-            f"{first.get('symbol')} at {first.get('currency')} {first.get('unit_price')} on {first.get('date')}."
-        )
-        response = f"I found {total_count} recent transactions. {snippet}\n\n{DISCLAIMER}"
-        fact_grounded = f"I found {total_count} recent transactions." in response
+        lines = [f"Here are your {total_count} most recent transactions:"]
+        for tx in txs:
+            lines.append(
+                f"  - {tx.get('date')}: {tx.get('type')} {tx.get('quantity')} "
+                f"{tx.get('symbol')} at {tx.get('currency')} {tx.get('unit_price')}"
+                f" (fee: {tx.get('fee', 0)})"
+            )
+        response = "\n".join(lines) + f"\n\n{DISCLAIMER}"
+        fact_grounded = f"{total_count} most recent transactions" in response
         return response, fact_grounded
 
     # Fallback

--- a/app/tools.py
+++ b/app/tools.py
@@ -70,6 +70,8 @@ async def get_transactions(
             filtered = [item for item in filtered if item.get("symbol", "").upper() == symbol.upper()]
         if tx_type:
             filtered = [item for item in filtered if item.get("type", "").upper() == tx_type.upper()]
+        # Sort newest-first so the most recent transactions appear at the top
+        filtered.sort(key=lambda t: t.get("date", ""), reverse=True)
         filtered = filtered[: max(limit, 1)]
 
         return ToolResult(success=True, data={"transactions": filtered, "total_count": len(filtered)})


### PR DESCRIPTION
## Summary
- Ghostfolio API returns orders sorted by date ascending (oldest first). The agent took `txs[0]` and labeled it "Most recent transaction" — showing the **oldest** one instead.
- Response only displayed 1 transaction despite fetching up to 5.

### Changes
- **`app/tools.py`**: Sort transactions by date descending before slicing to limit
- **`app/agent.py`**: Render all returned transactions as a list (date, type, quantity, symbol, price, fee) instead of just the first one

## Test plan
- [x] All 57 tests pass
- [x] Ruff lint clean
- [ ] Manual: ask "Show me my recent transactions" — should list multiple transactions, newest first

🤖 Generated with [Claude Code](https://claude.com/claude-code)