### PR TITLE
Add welcome message with example prompts

### DIFF
--- a/ui/streamlit_app.py
+++ b/ui/streamlit_app.py
@@ -65,6 +65,19 @@ with st.sidebar:
         st.session_state.session_connected = False
         st.rerun()
 
+if not st.session_state.messages:
+    with st.chat_message("assistant"):
+        st.markdown(
+            "Welcome! I'm your Ghostfolio portfolio assistant. "
+            "I can help you explore your portfolio data. Try asking:\n\n"
+            '- **"What\'s my portfolio worth?"** — portfolio value and top holdings\n'
+            '- **"How has my portfolio performed this year?"** — YTD returns\n'
+            '- **"Show me my recent transactions"** — latest buy/sell activity\n'
+            '- **"Analyze my allocation"** — sector, region, and asset class breakdown\n'
+            '- **"Check my portfolio risk"** — concentration and diversification checks\n'
+            '- **"What are my account balances?"** — linked accounts overview\n'
+        )
+
 for message in st.session_state.messages:
     with st.chat_message(message["role"]):
         st.markdown(message["content"])


### PR DESCRIPTION
## Summary
- Shows a greeting message from the assistant when the chat is empty
- Lists 6 example prompts covering all major tool capabilities
- Disappears once the user sends their first message

## Test plan
- [ ] Open UI with fresh session — welcome message visible
- [ ] Send a message — welcome message replaced by conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)