### PR TITLE
Extract symbols from query for LLM mode compatibility

### DIFF
--- a/app/agent.py
+++ b/app/agent.py
@@ -247,7 +247,10 @@ def _synthesize_response(state: AgentState) -> tuple[str, bool]:
         currency = str(data["currency"])
         count = int(data["holdings_count"])
         holdings = data.get("holdings", [])
-        filter_symbols = state.get("tool_args", {}).get("filter_symbols", [])
+        # Check both tool_args (rule-based) and original query (LLM mode) for symbols
+        filter_symbols = state.get("tool_args", {}).get("filter_symbols", []) or _extract_symbols(
+            state.get("query", "")
+        )
 
         if filter_symbols and holdings:
             # User asked about specific symbols — search the full holdings list


### PR DESCRIPTION
The filter_symbols approach only worked in rule-based mode. In LLM mode the LLM doesn't pass filter_symbols. Now also extracts symbols from the original query text so symbol-specific search works in both modes.