### PR TITLE
Add OpenRouter support for configurable agent model

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -20,6 +20,10 @@ class Settings(BaseSettings):
     anthropic_model: str = "claude-sonnet-4-20250514"
     llm_enabled: bool = True
 
+    # OpenRouter — unified LLM gateway (takes priority when configured)
+    openrouter_api_key: str = ""
+    agent_model: str = ""  # e.g. gpt-o, gpt-mini, claude-haiku, claude-sonnet, claude-opus
+
     # Langfuse observability
     langfuse_public_key: str = ""
     langfuse_secret_key: str = ""

--- a/app/llm.py
+++ b/app/llm.py
@@ -1,4 +1,4 @@
-"""LLM factory — OpenAI first, Anthropic fallback, None if no keys."""
+"""LLM factory — OpenRouter (preferred), OpenAI, Anthropic fallback, None if no keys."""
 
 from __future__ import annotations
 
@@ -12,6 +12,45 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+# Friendly name → OpenRouter model ID
+OPENROUTER_MODELS: dict[str, str] = {
+    "gpt-o": "openai/o4-mini",
+    "gpt-mini": "openai/gpt-4.1-mini",
+    "claude-haiku": "anthropic/claude-haiku-4-5-20251001",
+    "claude-sonnet": "anthropic/claude-sonnet-4-20250514",
+    "claude-opus": "anthropic/claude-opus-4-20250514",
+}
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+def _resolve_openrouter_model(agent_model: str) -> str | None:
+    """Map a friendly model name to an OpenRouter model ID."""
+    key = agent_model.strip().lower()
+    if key in OPENROUTER_MODELS:
+        return OPENROUTER_MODELS[key]
+    # Allow passing a raw OpenRouter model ID directly (e.g. "openai/gpt-4.1")
+    if "/" in agent_model:
+        return agent_model
+    return None
+
+
+def get_active_model_name() -> str:
+    """Return the display name of the active LLM model."""
+    if not settings.llm_enabled:
+        return "rule-based (no LLM)"
+
+    if settings.openrouter_api_key and settings.agent_model:
+        model_id = _resolve_openrouter_model(settings.agent_model)
+        if model_id:
+            return f"{settings.agent_model} ({model_id})"
+
+    if settings.openai_api_key:
+        return settings.openai_model
+    if settings.anthropic_api_key:
+        return settings.anthropic_model
+    return "rule-based (no LLM)"
+
 
 def get_llm() -> BaseChatModel | None:
     """Return the best available chat model, or None when no API keys are set."""
@@ -19,6 +58,32 @@ def get_llm() -> BaseChatModel | None:
         logger.info("llm_disabled", extra={"reason": "llm_enabled=False"})
         return None
 
+    # OpenRouter takes priority when both api key and model are configured
+    if settings.openrouter_api_key and settings.agent_model:
+        model_id = _resolve_openrouter_model(settings.agent_model)
+        if model_id:
+            try:
+                from langchain_openai import ChatOpenAI
+
+                logger.info(
+                    "llm_selected",
+                    extra={"provider": "openrouter", "model": model_id, "agent_model": settings.agent_model},
+                )
+                return ChatOpenAI(
+                    model=model_id,
+                    api_key=settings.openrouter_api_key,
+                    base_url=OPENROUTER_BASE_URL,
+                    temperature=0,
+                )
+            except Exception as exc:
+                logger.warning("llm_openrouter_init_failed", extra={"error": str(exc)})
+        else:
+            logger.warning(
+                "llm_openrouter_unknown_model",
+                extra={"agent_model": settings.agent_model, "available": list(OPENROUTER_MODELS.keys())},
+            )
+
+    # Direct OpenAI fallback
     if settings.openai_api_key:
         try:
             from langchain_openai import ChatOpenAI
@@ -32,6 +97,7 @@ def get_llm() -> BaseChatModel | None:
         except Exception as exc:
             logger.warning("llm_openai_init_failed", extra={"error": str(exc)})
 
+    # Direct Anthropic fallback
     if settings.anthropic_api_key:
         try:
             from langchain_anthropic import ChatAnthropic

--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,7 @@ from app.config import settings
 from app.data_sources import build_provider
 from app.data_sources.ghostfolio_api_provider import GhostfolioAPIDataProvider
 from app.ghostfolio_client import GhostfolioClient
+from app.llm import get_active_model_name
 from app.schemas import (
     DATA_SOURCE_GHOSTFOLIO_API,
     ChatRequest,
@@ -36,18 +37,11 @@ SESSION_TOKENS: dict[str, str] = {}
 async def health() -> dict[str, str]:
     logger.debug("health_check", extra={"data_source": settings.default_data_source})
 
-    if settings.llm_enabled and settings.openai_api_key:
-        llm_model = settings.openai_model
-    elif settings.llm_enabled and settings.anthropic_api_key:
-        llm_model = settings.anthropic_model
-    else:
-        llm_model = "rule-based (no LLM)"
-
     return {
         "status": "ok",
         "data_source": settings.default_data_source,
         "ghostfolio_url": settings.ghostfolio_base_url,
-        "llm_model": llm_model,
+        "llm_model": get_active_model_name(),
     }
 
 


### PR DESCRIPTION
## Summary
Adds OpenRouter as a unified LLM gateway, configurable via two env vars:

| Env var | Description |
|---------|-------------|
| `GHOSTFOLIO_OPENROUTER_API_KEY` | OpenRouter API key |
| `GHOSTFOLIO_AGENT_MODEL` | Model to use (see below) |

**Available models:**
| Friendly name | OpenRouter model ID |
|---------------|-------------------|
| `gpt-o` | `openai/o4-mini` |
| `gpt-mini` | `openai/gpt-4.1-mini` |
| `claude-haiku` | `anthropic/claude-haiku-4-5-20251001` |
| `claude-sonnet` | `anthropic/claude-sonnet-4-20250514` |
| `claude-opus` | `anthropic/claude-opus-4-20250514` |

You can also pass a raw OpenRouter model ID (e.g. `openai/gpt-4.1`).

**Priority:** OpenRouter > direct OpenAI key > direct Anthropic key > rule-based.

No new dependencies — OpenRouter uses an OpenAI-compatible API so `langchain-openai` works with a custom `base_url`. The sidebar displays the active model.

## Test plan
- [x] All 57 tests pass
- [x] Ruff lint clean
- [ ] Set `GHOSTFOLIO_OPENROUTER_API_KEY` and `GHOSTFOLIO_AGENT_MODEL=claude-sonnet` → verify model used
- [ ] Switch to `gpt-mini` → verify different model in sidebar and responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)